### PR TITLE
Fix #41: Fix authentication failure handling during download

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,9 @@ pub enum Error {
 
     #[error("Incrrect url format")]
     UrlIncorrectFormat,
+
+    #[error("Authentication failed")]
+    AuthenticationError,
 }
 
 macro_rules! errorln {
@@ -62,7 +65,8 @@ pub fn handle_error(e: Error) {
             errorln!("I/O処理でエラーが発生しました: {}", err);
         }
         Error::Internal(err) => {
-            errorln!("内部エラーが発生しました。\nError: {}", err);
+            errorln!("内部エラーが発生しました。");
+            errorln!("{}", err);
         }
         Error::CookiePathUnvaliable => {
             errorln!("Cookieファイルのパス取得に失敗しました。");
@@ -100,6 +104,9 @@ pub fn handle_error(e: Error) {
         Error::UrlIncorrectFormat => {
             errorln!("URLの形式が正しくありません。正しい形式で入力して下さい。");
             errorln!("Example: https://recursionist.io/dashboard/problems/1");
+        }
+        Error::AuthenticationError => {
+            errorln!("認証に失敗しました。ログインし直して下さい。");
         }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -217,9 +217,7 @@ fn fetch_problem_page(url: &str) -> Result<HTML, Error> {
 
     let final_url = res.url().as_str();
     if final_url != url {
-        return Err(Error::Internal(
-            "Unexpected redirect in fetch_problem_page".to_string(),
-        ));
+        return Err(Error::AuthenticationError);
     }
 
     println!("[{}] {}", *NETWORK_LABEL, res.status());


### PR DESCRIPTION
ダウンロード時に、認証情報の有効期限が切れていた場合のエラー処理を修正

認証情報が切れていることをユーザーに通知できていなかったので、その旨を表示できるように修正した

また、内部エラー時のエラーメッセージについても修正