### PR TITLE
Fix #79: Update installation process

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,17 +1,10 @@
 @echo off
 setlocal
 
-:: Cargo.tomlからversionを抽出
-for /f "tokens=2 delims== " %%v in ('findstr /b /c:"version =" Cargo.toml') do (
-    set "TAG=%%~v"
-)
-set "TAG=%TAG:"=%"
-set "TAG=v%TAG: =%"
-
 set REPO=kip2/rlr
 set FILE=rlr-x86_64-pc-windows-msvc.zip
 set INSTALL_DIR=%USERPROFILE%\rlr-bin
-set URL=https://github.com/%REPO%/releases/download/%TAG%/%FILE%
+set URL=https://github.com/%REPO%/releases/latest/download/%FILE%
 
 echo Downloading %URL%
 curl -L -o %FILE% %URL%

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-TAG="v$(grep '^version =' Cargo.toml | sed -E 's/version = \"(.*)\"/\1/')"
 REPO="kip2/rlr"
 BINARY="rlr"
 TARGET="x86_64-unknown-linux-gnu"
@@ -11,7 +10,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
 fi
 
 FILE="${BINARY}-${TARGET}.tar.gz"
-URL="https://github.com/${REPO}/releases/download/${TAG}/${FILE}"
+URL="https://github.com/${REPO}/releases/latest/download/${FILE}"
 
 INSTALL_DIR="$HOME/.local/bin"
 mkdir -p "$INSTALL_DIR"


### PR DESCRIPTION
インストールがリリースタグ番号に紐づいていたのを修正